### PR TITLE
this modifies Externals.cfg to point to the nuopc_updates branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,6 @@
 
 [cice]
-branch = nuopc
+branch = nuopc_updates
 protocol = git
 repo_url = https://github.com/ESCOMP/CICE
 local_path = src


### PR DESCRIPTION
This PR should hopefully resolve the issues with building cice6.