### PR TITLE
black reformat buildlib

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -17,35 +17,70 @@ logger = logging.getLogger(__name__)
 
 ###############################################################################
 def _build_cice():
-###############################################################################
+    ###############################################################################
 
     caseroot, libroot, bldroot = parse_input(sys.argv)
 
     with Case(caseroot) as case:
         casetools = case.get_value("CASETOOLS")
-        gmake_j   = case.get_value("GMAKE_J")
-        gmake     = case.get_value("GMAKE")
-        srcroot   = case.get_value("SRCROOT")
-        driver    = case.get_value("COMP_INTERFACE")
+        gmake_j = case.get_value("GMAKE_J")
+        gmake = case.get_value("GMAKE")
+        srcroot = case.get_value("SRCROOT")
+        driver = case.get_value("COMP_INTERFACE")
 
         # create Filepath file
         objroot = case.get_value("OBJROOT")
-        filepath_file = os.path.join(objroot,"ice","obj","Filepath")
+        filepath_file = os.path.join(objroot, "ice", "obj", "Filepath")
         if not os.path.isfile(filepath_file):
             srcroot = case.get_value("SRCROOT")
             caseroot = case.get_value("CASEROOT")
             comp_root_dir_ice = case.get_value("COMP_ROOT_DIR_ICE")
-            paths = [os.path.join(caseroot,"SourceMods","src.cice"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","shared"),
-                     os.path.join(comp_root_dir_ice,"src","icepack","columnphysics"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","infrastructure"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","infrastructure","io","io_pio2"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","infrastructure","comm","mpi"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","analysis"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","dynamics"),
-                     os.path.join(comp_root_dir_ice,"src","cicecore","cicedynB","general")]
-            if driver == 'nuopc':
-                paths.append(os.path.join(comp_root_dir_ice,"src","cicecore","drivers","nuopc","cmeps"))
+            paths = [
+                os.path.join(caseroot, "SourceMods", "src.cice"),
+                os.path.join(comp_root_dir_ice, "src", "cicecore", "shared"),
+                os.path.join(comp_root_dir_ice, "src", "icepack", "columnphysics"),
+                os.path.join(
+                    comp_root_dir_ice, "src", "cicecore", "cicedynB", "infrastructure"
+                ),
+                os.path.join(
+                    comp_root_dir_ice,
+                    "src",
+                    "cicecore",
+                    "cicedynB",
+                    "infrastructure",
+                    "io",
+                    "io_pio2",
+                ),
+                os.path.join(
+                    comp_root_dir_ice,
+                    "src",
+                    "cicecore",
+                    "cicedynB",
+                    "infrastructure",
+                    "comm",
+                    "mpi",
+                ),
+                os.path.join(
+                    comp_root_dir_ice, "src", "cicecore", "cicedynB", "analysis"
+                ),
+                os.path.join(
+                    comp_root_dir_ice, "src", "cicecore", "cicedynB", "dynamics"
+                ),
+                os.path.join(
+                    comp_root_dir_ice, "src", "cicecore", "cicedynB", "general"
+                ),
+            ]
+            if driver == "nuopc":
+                paths.append(
+                    os.path.join(
+                        comp_root_dir_ice,
+                        "src",
+                        "cicecore",
+                        "drivers",
+                        "nuopc",
+                        "cmeps",
+                    )
+                )
             else:
                 expect(False, "only the CMEPS nuopc driver is current supported")
 
@@ -55,24 +90,34 @@ def _build_cice():
 
         # set the cice_cppdefs
         cice_cppdefs = " -Dncdf"
-        if (case.get_value("COMP_ATM") == 'fv3gfs' and case.get_value("COMP_OCN") == "mom"):
+        if (
+            case.get_value("COMP_ATM") == "fv3gfs"
+            and case.get_value("COMP_OCN") == "mom"
+        ):
             # the following is only relevant if the UFS S2S uses CIME
             cice_cppdefs = cice_cppdefs + " -DNEMS_COUPLED"
-        if "ar9v" in case.get_value('ICE_GRID'):
+        if "ar9v" in case.get_value("ICE_GRID"):
             # trigger RASM options with ar9v grid, otherwise set CESM options
             cice_cppdefs = cice_cppdefs + " -DRASM_MODS"
 
         # build the library
-        complib = os.path.join(libroot,"libice.a")
+        complib = os.path.join(libroot, "libice.a")
         makefile = os.path.join(casetools, "Makefile")
 
-        cmd = "{} complib -j {} COMP_NAME=cice COMPLIB={} -f {} USER_CPPDEFS=\"{}\" {} " \
-            .format(gmake, gmake_j, complib, makefile, cice_cppdefs, get_standard_makefile_args(case))
+        cmd = '{} complib -j {} COMP_NAME=cice COMPLIB={} -f {} USER_CPPDEFS="{}" {} '.format(
+            gmake,
+            gmake_j,
+            complib,
+            makefile,
+            cice_cppdefs,
+            get_standard_makefile_args(case),
+        )
 
         rc, out, err = run_cmd(cmd, from_dir=bldroot)
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
 
-        logger.info("Command %s completed with output %s\nerr %s" ,cmd, out, err)
+        logger.info("Command %s completed with output %s\nerr %s", cmd, out, err)
+
 
 if __name__ == "__main__":
     _build_cice()


### PR DESCRIPTION
Use black to reformat this file so that the format is consistant for all python in cesm.