### PR TITLE
Add ".gitignore" file to ignore compiled python.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore non-source python files:
+__pycache__
+*.py[cod]
+


### PR DESCRIPTION
While testing git-fleximod in CAM @cacraigucar found that compiled python directories and files were showing up with various git commands (e.g. `git status`) under the cice directory.  This PR should prevent that from happening, assuming that there is no reason to ever commit compiled python files here.

Also, I should note that I am not familiar with the official development workflow for this repo.  So if I need to make an issue, update a `ChangeLog` file, etc. please let me know.  Thanks!