### PR TITLE
Remove glob rootdir

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -247,8 +247,9 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         # find the most recent file matching pattern
         cice_ptr = None
         pattern = "rpointer.ice*"
-        files = glob.glob(pattern, root_dir=rundir)
-        files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        with chdir(rundir):
+            files = glob.glob(pattern)
+            files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
         if files:
             cice_ptr = files[-1]
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -247,9 +247,10 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         # find the most recent file matching pattern
         cice_ptr = None
         pattern = "rpointer.ice*"
-        with chdir(rundir):
-            files = glob.glob(pattern)
-            files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        os.chdir(rundir)
+        files = glob.glob(pattern)
+        files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        os.chdir(case.get_case_root())
         if files:
             cice_ptr = files[-1]
 


### PR DESCRIPTION
The glob.glob root_dir option was added in Python 3.10,
This reverts this option so that older versions of python are supported.  