### PR TITLE
Fix ice_ic for branch and hybrid runs with ninst>1

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -212,7 +212,7 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         run_refcase = case.get_value("RUN_REFCASE")
         run_refdate = case.get_value("RUN_REFDATE")
         run_tod     = case.get_value("RUN_REFTOD")
-        ice_ic = "%s.cice.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
+        ice_ic = "%s.cice%s.r.%s-%s.nc" %(run_refcase, inst_string, run_refdate, run_tod)
         nmlgen.add_default("ice_ic", value=ice_ic, ignore_abs_path=True)
     else:
         nmlgen.add_default("ice_ic")

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -50,6 +50,11 @@
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
+  <test name="ERI_C2" grid="T62_g17" compset="DTEST" testmods="cice/default">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cice"/>
+    </machines>
+  </test>
 
   <!-- ================= -->
   <!-- G TEST -->


### PR DESCRIPTION
fixes #29 

Cherry-picked commits from my NorESM_CICE pr branch. `ERI_C2_D_Ld10.TL319_tn14.NOIIAJRA.betzy_intel`  PASSED.
Long compset has CICe active: `2000_DATM%JRA-1p4-2018_SLND_CICE_BLOM%HYB_DROF%JRA-1p4-2018_SGLC_SWAV`

@jedwards4b @dabail10 I've added a test in aux_cice, just in case. 