### PR TITLE
fix archiving of timestamped rpointer files

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -5,11 +5,13 @@
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ice$NINST_STRING.$DATENAME</rpointer_file>
       <rpointer_content>./$CASE.cice$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
     <test_file_names>
-      <tfile disposition="copy">rpointer.ice</tfile>
+      <tfile disposition="copy">rpointer.ice.1976-01-01-00000</tfile>
+      <tfile disposition="ignore">rpointer.ice.1976-01-01-08320</tfile>
+      <tfile disposition="copy">rpointer.ice_9999.1976-01-01-00000</tfile>
       <tfile disposition="copy">casename.cice.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cice.h.1976-01-01-00000.nc</tfile>
     </test_file_names>


### PR DESCRIPTION
Tested using fully coupled compset with interim restart files and
DOUT_S_SAVE_INTERIM_RESTART_FILES=TRUE, FALSE. 