### PR TITLE
Make CESM's st_archive handle CICE+DART output files.

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -2,7 +2,8 @@
 
   <comp_archive_spec compname="cice" compclass="ice">
     <rest_file_extension>[ri]</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h\d*.*\.nc(\.gz)?$</hist_file_extension>
+    <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>


### PR DESCRIPTION
The proposed changes involve only st_archive; putting DART's (esp) .e. files into the right places
and handling compressed (.gz) files, which is extremely useful in multi-instance data assimilation runs.
The do not change the st_archive locations of non-DART CICE files.

Please see [the discussion](https://bb.cgd.ucar.edu/cesm/threads/easy-enhancement-make-st_archive-handle-output-files-from-cice-dart.11380/) for more description of these changes and testing.
Or I'll import it here, if that's preferable.

